### PR TITLE
ประเมินและปรับปรุงเว็บไซต์

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,14 +1,16 @@
+import Link from 'next/link';
+
 export default function NotFound() {
   return (
     <div className="page-enter page-enter-active">
       <h1>Page not found</h1>
       <p className="muted">The page you are looking for does not exist.</p>
       <div className="footer-nav" style={{marginTop: 12}}>
-        <a className="button ghost" href="/en">Home</a>
-        <a className="button ghost" href="/en/loan">Loan</a>
-        <a className="button ghost" href="/en/mortgage">Mortgage</a>
-        <a className="button ghost" href="/en/tax">Tax</a>
-        <a className="button ghost" href="/en/insurance">Insurance</a>
+        <Link className="button ghost" href="/en">Home</Link>
+        <Link className="button ghost" href="/en/loan">Loan</Link>
+        <Link className="button ghost" href="/en/mortgage">Mortgage</Link>
+        <Link className="button ghost" href="/en/tax">Tax</Link>
+        <Link className="button ghost" href="/en/insurance">Insurance</Link>
       </div>
     </div>
   );

--- a/lib/ConsentBannerClient.tsx
+++ b/lib/ConsentBannerClient.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { t } from '@/lib/i18n';
+import { getLangFromPath } from '@/lib/path';
 
 const CONSENT_KEY = "fh-consent";
 
@@ -11,6 +14,8 @@ type Props = { onChange?: (consented: boolean) => void };
 export default function ConsentBannerClient({ onChange }: Props) {
 	const [choice, setChoice] = useState<ConsentValue>(null);
 	const [visible, setVisible] = useState(false);
+	const pathname = usePathname() || '/';
+	const lang = getLangFromPath(pathname);
 
 	useEffect(() => {
 		if (typeof window === "undefined") return;
@@ -38,10 +43,10 @@ export default function ConsentBannerClient({ onChange }: Props) {
 		<div style={{ position: 'fixed', bottom: 12, left: 12, right: 12, zIndex: 1000 }}>
 			<div style={{ maxWidth: 960, margin: '0 auto' }}>
 				<div className="card" role="dialog" aria-live="polite" aria-label="Consent">
-					<p style={{ marginTop: 0, marginBottom: 8 }}>We use anonymized analytics after consent. You can change your choice anytime.</p>
+					<p style={{ marginTop: 0, marginBottom: 8 }}>{t(lang, 'consentMessage')}</p>
 					<div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-						<button className="button" onClick={() => decide("accepted")}>Accept</button>
-						<button className="button ghost" onClick={() => decide("declined")}>Decline</button>
+						<button className="button" onClick={() => decide("accepted")}>{t(lang, 'accept')}</button>
+						<button className="button ghost" onClick={() => decide("declined")}>{t(lang, 'decline')}</button>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Localize consent banner text and update 404 page navigation to use Next.js Link components.

The consent banner now displays messages in the current language, improving internationalization. The 404 page links are updated to use Next.js `Link` components, ensuring they correctly handle `basePath` configurations and leverage client-side routing.

---
<a href="https://cursor.com/background-agent?bcId=bc-03622110-98c0-49ba-a1e1-23fb5f3120ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-03622110-98c0-49ba-a1e1-23fb5f3120ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

