### PR TITLE
Combine language buttons to single URL

### DIFF
--- a/lib/HeaderClient.tsx
+++ b/lib/HeaderClient.tsx
@@ -55,19 +55,17 @@ export default function HeaderClient() {
           <div className="hide-on-mobile" style={{ minWidth: 220 }}>
             <SearchClient lang={currentLang} />
           </div>
-          <label className="select" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-            <span className="sr-only">{t(currentLang, 'language')}</span>
-            <select
-              aria-label={t(currentLang, 'language')}
-              value={currentLang}
-              onChange={(e) => router.push(replaceLang(pathname, e.target.value) as any)}
-              style={{ background: 'transparent', border: 'none', outline: 'none' }}
-            >
-              {SUPPORTED_LANGS.map((lc) => (
-                <option key={lc} value={lc}>{getNativeName(lc)}</option>
-              ))}
-            </select>
-          </label>
+          <button
+            className="button ghost"
+            aria-label={t(currentLang, 'language')}
+            onClick={() => {
+              const nextLang = currentLang === 'th' ? 'en' : 'th';
+              router.push(replaceLang(pathname, nextLang) as any);
+            }}
+            title={getNativeName(currentLang === 'th' ? 'en' : 'th')}
+          >
+            {currentLang === 'th' ? 'EN' : 'TH'}
+          </button>
           <label className="select" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
             <span className="sr-only">Country</span>
             <select


### PR DESCRIPTION
Consolidated the language switcher into a single TH/EN toggle button, maintaining a consistent URL pattern.

---
<a href="https://cursor.com/background-agent?bcId=bc-eff985d7-5a27-4e55-ac94-723f258b769f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eff985d7-5a27-4e55-ac94-723f258b769f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

